### PR TITLE
Use env var for summary url

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ Ce dépôt GitHub contient :
 ```
 
 NTFYTOPICID=votre_id_de_topic_ntfy
+SUMMARYURL=https://YOUR_REGION-your_project.cloudfunctions.net/getNotesSummary
 
 ```
 
-Cette configration permet au site de fournir un tutoriel facile pour parametrer les notifications sur mobile facilement.
+`NTFYTOPICID` correspond au sujet ntfy pour recevoir les notifications sur mobile.
+`SUMMARYURL` doit pointer vers l'URL publique de votre fonction `getNotesSummary`.
 
 ### Installation et exécution locale
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+NTFYTOPICID=votre_id_de_topic_ntfy
+SUMMARYURL=https://YOUR_REGION-your_project.cloudfunctions.net/getNotesSummary

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -312,7 +312,7 @@ export const fetchGrades = async (demo: boolean = false) => {
 
   try {
     // Call Google Cloud Functions endpoint directly
-    const response = await fetch('https://us-central1-pokendystorm-ff671.cloudfunctions.net/getNotesSummary', {
+    const response = await fetch(import.meta.env.VITE_SUMMARY_URL || 'https://YOUR_REGION-your_project.cloudfunctions.net/getNotesSummary', {
       method: 'GET',
       headers: {
         'Accept': 'application/json',

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,5 +9,6 @@ export default defineConfig({
   },
   define: {
     'import.meta.env.VITE_NTFY_TOPIC_ID': JSON.stringify(process.env.NTFYTOPICID || 'dimitrisnotes'),
+    'import.meta.env.VITE_SUMMARY_URL': JSON.stringify(process.env.SUMMARYURL || 'https://YOUR_REGION-your_project.cloudfunctions.net/getNotesSummary'),
   },
 });


### PR DESCRIPTION
## Summary
- add SUMMARYURL in README example config
- allow summary URL injection via Vite
- read summary URL from env in supabase helper
- provide `.env.example` for frontend
- remove private sample URL

## Testing
- `npm run lint` *(fails: no-case-declarations and other issues)*


------
https://chatgpt.com/codex/tasks/task_e_684609810e908329857a9435e48f928d